### PR TITLE
add: Hermes agent setup and function

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -370,6 +370,7 @@ alias sbcl="rlwrap -r sbcl"
 tunnel_up()   { ssh -fN server && echo "tunnel up"; }
 tunnel_down() { pkill -f 'ssh -fN server' && echo "tunnel down" || echo "no tunnel"; }
 opencode_ollama() { tunnel_up && opencode }
+hermes() { podman run -it --rm --network=host --userns=keep-id:uid=10000,gid=10000 -v $HOME/.hermes:/opt/data:z nousresearch/hermes-agent "$@" } # Pass through any arguments so you can do hermes setup model et
 server_sleep() { systemctl suspend && echo "server suspended"; }
 ollama_self_update() { # Update the Ollama binary itself (Linux & macOS)
   if ! command -v curl >/dev/null 2>&1; then

--- a/hermes_setup.sh
+++ b/hermes_setup.sh
@@ -1,0 +1,75 @@
+
+#!/usr/bin/env zsh
+set -e
+
+IMAGE="nousresearch/hermes-agent"
+DATA="$HOME/.hermes"
+UID_=$(id -u)
+SERVICE_DIR="$HOME/.config/systemd/user"
+
+echo ">>> Pulling Hermes image..."
+podman pull "$IMAGE"
+
+echo ">>> Creating data directories..."
+mkdir -p "$DATA"/{cron,sessions,logs,hooks,memories,skills,skins,plans,workspace,home}
+chmod 777 "$DATA"
+
+echo ">>> Running interactive setup (follow the prompts)..."
+echo "    Use http://localhost:11434/v1 as your endpoint"
+podman run -it --rm \
+  --network=host \
+  --userns=keep-id:uid=10000,gid=10000 \
+  -v "$DATA:/opt/data:z" \
+  "$IMAGE" setup
+
+echo ">>> Creating systemd user service..."
+mkdir -p "$SERVICE_DIR"
+cat > "$SERVICE_DIR/hermes.service" << EOF
+[Unit]
+Description=Hermes Agent Daemon
+After=network.target
+
+[Service]
+ExecStart=podman run --rm \
+  --name hermes \
+  --network=host \
+  --userns=keep-id:uid=10000,gid=10000 \
+  -v $DATA:/opt/data:z \
+  $IMAGE gateway run
+ExecStop=podman stop hermes
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable hermes
+
+echo ">>> Creating sleep hook (needs sudo)..."
+HOOK=/etc/systemd/system-sleep/hermes-sleep
+[ ! -d /etc/systemd/system-sleep ] && sudo mkdir /etc/systemd/system-sleep
+sudo tee "$HOOK" > /dev/null << EOF
+#!/bin/bash
+case \$1 in
+  pre)
+    sudo -u $(whoami) XDG_RUNTIME_DIR=/run/user/$UID_ systemctl --user stop hermes
+    ;;
+  post)
+    sudo -u $(whoami) XDG_RUNTIME_DIR=/run/user/$UID_ systemctl --user start hermes
+    ;;
+esac
+EOF
+sudo chmod +x "$HOOK"
+
+echo ">>> Adding hermes() function to ~/.zshrc..."
+FUNC='hermes() { podman run -it --rm --network=host --userns=keep-id:uid=10000,gid=10000 -v $HOME/.hermes:/opt/data:z nousresearch/hermes-agent "$@" }'
+grep -qF 'nousresearch/hermes-agent' ~/.zshrc || echo "$FUNC" >> ~/.zshrc
+echo "    Run 'source ~/.zshrc' or open a new terminal, then just type: hermes"
+
+echo ">>> Starting Hermes..."
+systemctl --user start hermes
+
+echo ""
+echo "All done! Check status with: systemctl --user status hermes"
+


### PR DESCRIPTION
This pull request introduces support for running the Hermes agent using Podman, including a new setup script and shell integration. The main changes add a convenient shell function for launching Hermes containers and provide an automated setup script that handles image pulling, directory creation, interactive setup, systemd user service configuration, and sleep/wake integration.

**Hermes agent integration and setup:**

* Added a new `hermes()` shell function to `.zshrc` for easily running the Hermes agent container with Podman, passing through any arguments.
* Added a new `hermes_setup.sh` script that automates:
  - Pulling the Hermes agent image,
  - Creating necessary data directories,
  - Running the interactive setup,
  - Creating a systemd user service for Hermes,
  - Adding a system sleep/wake hook to stop/start the service,
  - Appending the `hermes()` function to `.zshrc` if not present,
  - Starting the Hermes service.